### PR TITLE
Use player config builder

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Need some guidance? Check out our tutorial on [how to use the Bitmovin web playe
 * tip: If continuous running of `DEVICE=<ip|host> npm run debug` does not work you first need to kill the app by running `DEVICE=<ip|host> npm run stop` and then run debug again.
 
 ### Notes for developing your own app
-Make sure to enable `file_protocol` and set your `app_id` in the `tweaks` section of your config
+Make sure to enable `file_protocol` and set your `app_id` in the `tweaks` section of your config, or use the PlayerConfigBuilder. 
 
 ```
 var conf = {

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -60,44 +60,22 @@ function setupPlayer() {
   // Analytics
   bitmovin.player.core.Player.addModule(window.bitmovin.analytics.PlayerModule);
 
-  var conf = {
-    key: PLAYER_KEY,
-    playback: {
-      autoplay: true,
-      preferredTech: [
-        {
-          player: 'html5',
-          streaming: 'dash',
-        },
-      ],
-    },
-    style: {
-      ux: false,
-    },
-    tweaks: {
-      file_protocol: true,
-      app_id: APP_ID,
-      BACKWARD_BUFFER_PURGE_INTERVAL: 10,
-    },
-    buffer: {
-      video: {
-        forwardduration: 30,
-        backwardduration: 10,
-      },
-      audio: {
-        forwardduration: 30,
-        backwardduration: 10,
-      },
-    },
-    analytics: {
-      key: ANALYTICS_KEY,
-      videoId: "AOM",
-      title: "Art Of Motion Analytics Test",
-      config: {
-        origin: APP_ID
-      }
-    },
-    ui: false,
+  
+  const conf = new bitmovin.player.core.util.PlayerConfigBuilder(PLAYER_KEY)
+    .optimizeForPlatform({ appId: APP_ID })
+    .build();
+
+  // disable the default UI
+  conf.style = {
+    ux: false,
+  };
+  conf.ui = false;
+
+  // analytics defaults get applied by the config builder
+  conf.analytics = {
+    ...conf.analytics,
+    videoId: "AOM",
+    title: "Art Of Motion Analytics Test",
   };
 
   var container = document.getElementById('player');

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -69,11 +69,7 @@ function setupPlayer() {
   conf.ui = false;
 
   // analytics defaults get applied by the config builder
-  conf.analytics = {
-    ...conf.analytics,
-    videoId: "AOM",
-    title: "Art Of Motion Analytics Test",
-  };
+conf.analytics.customUserId = 'my-custom-user-id';
 
   var container = document.getElementById('player');
   player = new bitmovin.player.core.Player(container, conf);

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -71,7 +71,7 @@ function setupPlayer() {
   // disable the default UI
   conf.ui = false;
 
-  // analytics defaults get applied by the config builder
+  // analytics defaults get applied by the config builder on TV models
   conf.analytics.customUserId = 'my-custom-user-id';
 
   var container = document.getElementById('player');

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -16,6 +16,10 @@ var source = {
     },
   },
   title: 'Art of Motion',
+  analytics: {
+    videoId: "AOM",
+    title: "Art Of Motion Analytics Test",
+  }
 };
 
 window.onload = function () {
@@ -60,7 +64,6 @@ function setupPlayer() {
   // Analytics
   bitmovin.player.core.Player.addModule(window.bitmovin.analytics.PlayerModule);
 
-  
   const conf = new bitmovin.player.core.util.PlayerConfigBuilder(PLAYER_KEY)
     .optimizeForPlatform({ appId: APP_ID })
     .build();
@@ -69,7 +72,7 @@ function setupPlayer() {
   conf.ui = false;
 
   // analytics defaults get applied by the config builder
-conf.analytics.customUserId = 'my-custom-user-id';
+  conf.analytics.customUserId = 'my-custom-user-id';
 
   var container = document.getElementById('player');
   player = new bitmovin.player.core.Player(container, conf);

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -66,9 +66,6 @@ function setupPlayer() {
     .build();
 
   // disable the default UI
-  conf.style = {
-    ux: false,
-  };
   conf.ui = false;
 
   // analytics defaults get applied by the config builder


### PR DESCRIPTION
This PR adds the usage of the newly introduced [PlayerConfigBuilder](https://cdn.bitmovin.com/player/web/8/docs/classes/Util.PlayerConfigBuilder.html)

This will help simplifying the setup of TV applications. 