### PR TITLE
Load desired DRM when not loaded already

### DIFF
--- a/src/js/main.js
+++ b/src/js/main.js
@@ -174,22 +174,29 @@ function isDrmLoaded(drmAgent) {
       return reject('No drmAgent');
     }
 
+    function loadDrmOnFailure() {
+      loadDrm(drmAgent)
+        .then(function (result) {
+          resolve(result);
+        })
+        .catch(function (err) {
+          reject(err);
+        });
+    }
+
     drmAgent.isLoaded({
       onSuccess: function (response) {
         if (response.loadStatus === true) {
           resolve(response);
         } else {
-          loadDrm(drmAgent)
-            .then(function (result) {
-              resolve(result);
-            })
-            .catch(function (err) {
-              reject(err);
-            });
+          loadDrmOnFailure();
         }
       },
       onFailure: function (err) {
-        reject(err);
+        // isLoaded check fails sometimes as the key system requested is not same as loaded
+        // load the desired key system in that case
+        console.error('Error while checking if DRM is loaded', err);
+        loadDrmOnFailure();
       },
     });
   });


### PR DESCRIPTION
When `isLoaded` of `DrmAgent` check fails, the promise of `isDrmLoaded` is rejected to abort source load. The check can fail if the already loaded DRM key system does not match with requested one.

Example, in our case we request `DrmAgent` with `Widevine` KeySystem and check if DRM is loaded. This can fail if `Playready` is loaded by the platform by default. In the failure case we should load the desired KeySystem instead of rejecting the promise.